### PR TITLE
Swiched nodes from name to id and now publishes node id list

### DIFF
--- a/lib/homieDevice.js
+++ b/lib/homieDevice.js
@@ -155,9 +155,14 @@ proto.onConnect = function() {
   // t.mqttClient.publish(t.mqttTopic + '/$localip', ?, {retain:true});
   // t.mqttClient.publish(t.mqttTopic + '/$stats/signal', ?, {retain:true});
 
+  var nodeIds = [];
   _.each(t.nodes, function(node){
     node.onConnect();
+    nodeIds.push(node.id);
   })
+  
+  t.mqttClient.publish(t.mqttTopic + "/$nodes", nodeIds.join(','), {retain:true});
+
   t.emit('connect');
 
   // Call the stats interval now, and at regular intervals

--- a/lib/homieNode.js
+++ b/lib/homieNode.js
@@ -2,14 +2,14 @@ var _ = require('lodash');
 var HomieProperty = require('./homieProperty');
 var EventEmitter = require('events').EventEmitter;
 
-var HomieNode = module.exports = function(homieDevice, name, type) {
+var HomieNode = module.exports = function(homieDevice, id, type) {
 
   var t = this;
   t.props = {};
-  t.name = name;
+  t.id = id;
   t.type = type;
   t.homieDevice = homieDevice;
-  t.mqttTopic = t.homieDevice.mqttTopic + '/' + t.name;
+  t.mqttTopic = t.homieDevice.mqttTopic + '/' + t.id;
 
 }
 

--- a/test/2-HomieNode.js
+++ b/test/2-HomieNode.js
@@ -17,7 +17,7 @@ describe("Homie Node", function() {
       expect(testNode1).to.be.an.instanceOf(HomieNode);
     });
     it("constructor arguments are correct", function() {
-      expect(testNode1.name).to.equal('test-node-1');
+      expect(testNode1.id).to.equal('test-node-1');
       expect(testNode1.type).to.equal('test-node');
     });
 
@@ -47,6 +47,17 @@ describe("Homie Node", function() {
       testNode1 = testDevice.node('test-node-1', 'test-node');
       testDevice.on('message:test-node-1/$type', function(msg) {
         expect(msg).to.equal('test-node');
+        testDevice.end();
+        done();
+      });
+      testDevice.setup(quietSetup);
+    });
+
+    it("publishes the node list on connect", function(done) {
+      testDevice = new HomieDevice('homie-device-test');
+      testNode1 = testDevice.node('test-node-1', 'test-node');
+      testDevice.on('message:$nodes', function(msg) {
+        expect(msg).to.equal('test-node-1');
         testDevice.end();
         done();
       });


### PR DESCRIPTION
Fixes #3 
Note that I changed node.name to node.id; I plan to add node.name too, which would be the friendly name.